### PR TITLE
GRAL-3505 App Extensions SDK event for window focus/unfocus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- New event `PAGE_VISIBILITY_STATE` to detect if Custom UI is in the visible browser tab
+
 ## [0.6.1] - 2023-01-10
 
 - Document `RESIZE` command constraints for floating windows

--- a/README.md
+++ b/README.md
@@ -518,3 +518,32 @@ sdk.listen(Event.CLOSE_CUSTOM_MODAL, () => {
   // handle event
 });
 ```
+
+### Page visibility state
+
+Subscribe to page visibility event that is triggered when the value of `visibilityState` property of the document changes.
+It is useful to know if the page is in the background or an invisible tab.
+
+| Parameter | Type   | Description                                                  | Notes    |
+| --------- | ------ | ------------------------------------------------------------ | -------- |
+| state     | String | Indicates if the page content is visible for the user or not | required |
+
+**Possible state values**
+
+`visible`
+
+The page content may be at least partially visible. In practice this means that the page is the foreground tab of a non-minimized window.
+
+`hidden`
+
+The page content is not visible to the user. In practice this means that the document is either a background tab or part of a minimized window, or the OS screen lock is active.
+
+**Example**
+
+```javascript
+const stopReceivingPageStateEvent = sdk.listen(Event.PAGE_VISIBILITY_STATE, ({ data }) => {
+  // handle data
+});
+
+stopReceivingPageStateEvent() // Call this function to stop receiving event
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,12 +136,14 @@ class AppExtensionsSDK {
 		return this;
 	}
 
-	public tabVisibilityListener(cb: (arg: { visibility: 'hidden' | 'visible' }) => void): void {
+	public onPageVisibilityChange(cb: (arg: { visibility: 'hidden' | 'visible' }) => void) {
 		const onChange = () => {
 			cb({ visibility: document.visibilityState });
 		};
 
 		document.addEventListener('visibilitychange', onChange);
+
+		return () => document.removeEventListener('visibilitychange', onChange);
 	}
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import {
 	Options,
 	Payload,
 	TrackingEvent,
-	PageVisibilityStateResponse,
+	PageStateResponse,
 } from './types';
 
 const commandKeys = Object.values(Command);
@@ -91,7 +91,7 @@ class AppExtensionsSDK {
 		this.window.postMessage(message, targetOrigin);
 	}
 
-	private onPageVisibilityChange(cb: (response: PageVisibilityStateResponse) => void) {
+	private onPageVisibilityChange(cb: (response: PageStateResponse) => void) {
 		const onChange = () => {
 			cb({ data: { state: document.visibilityState } });
 		};
@@ -107,7 +107,7 @@ class AppExtensionsSDK {
 		}
 
 		if (event === Event.PAGE_VISIBILITY_STATE) {
-			return this.onPageVisibilityChange(onEventReceived as (response: PageVisibilityStateResponse) => void);
+			return this.onPageVisibilityChange(onEventReceived as (response: PageStateResponse) => void);
 		}
 
 		const channel = new MessageChannel();

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,14 @@ class AppExtensionsSDK {
 
 		return this;
 	}
+
+	public tabVisibilityListener(cb: (arg: { visibility: 'hidden' | 'visible' }) => void): void {
+		const onChange = () => {
+			cb({ visibility: document.visibilityState });
+		};
+
+		document.addEventListener('visibilitychange', onChange);
+	}
 }
 
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import {
 	Options,
 	Payload,
 	TrackingEvent,
-	PageVisibilityStateArgs,
+	PageVisibilityStateResponse,
 } from './types';
 
 const commandKeys = Object.values(Command);
@@ -91,14 +91,14 @@ class AppExtensionsSDK {
 		this.window.postMessage(message, targetOrigin);
 	}
 
-	private onPageVisibilityChange(cb: (args: PageVisibilityStateArgs) => void) {
+	private onPageVisibilityChange(cb: (response: PageVisibilityStateResponse) => void) {
 		const onChange = () => {
-			cb({ state: document.visibilityState });
+			cb({ data: { state: document.visibilityState } });
 		};
 
 		document.addEventListener('visibilitychange', onChange);
 
-		return () => document.addEventListener('visibilitychange', onChange);
+		return () => document.removeEventListener('visibilitychange', onChange);
 	}
 
 	public listen<K extends Event>(event: K, onEventReceived: (response: EventResponse<K>) => void) {
@@ -107,7 +107,7 @@ class AppExtensionsSDK {
 		}
 
 		if (event === Event.PAGE_VISIBILITY_STATE) {
-			this.onPageVisibilityChange(onEventReceived as (args: PageVisibilityStateArgs) => void)
+			return this.onPageVisibilityChange(onEventReceived as (response: PageVisibilityStateResponse) => void);
 		}
 
 		const channel = new MessageChannel();

--- a/src/types.ts
+++ b/src/types.ts
@@ -225,3 +225,7 @@ export type RedirectAttributes = {
 	view: View;
 	id?: number | string;
 };
+
+export type PageVisibilityStateArgs = {
+	state: 'visible' | 'hidden'
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -226,6 +226,8 @@ export type RedirectAttributes = {
 	id?: number | string;
 };
 
-export type PageVisibilityStateArgs = {
-	state: 'visible' | 'hidden'
-}
+export type PageVisibilityStateResponse = {
+	data: {
+		state: 'visible' | 'hidden';
+	};
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -226,7 +226,7 @@ export type RedirectAttributes = {
 	id?: number | string;
 };
 
-export type PageVisibilityStateResponse = {
+export type PageStateResponse = {
 	data: {
 		state: 'visible' | 'hidden';
 	};

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export enum Command {
 export enum Event {
 	VISIBILITY = 'visibility',
 	CLOSE_CUSTOM_MODAL = 'close_custom_modal',
+	PAGE_VISIBILITY_STATE = 'page_visibility_state',
 }
 
 export enum MessageType {
@@ -196,6 +197,9 @@ export type EventResponse<T extends Event> = {
 			context?: Partial<Record<string, unknown> & Record<'invoker', VisibilityEventInvoker>>;
 		};
 		[Event.CLOSE_CUSTOM_MODAL]: void;
+		[Event.PAGE_VISIBILITY_STATE]: {
+			state: 'visible' | 'hidden';
+		};
 	}[T];
 };
 


### PR DESCRIPTION
Vendors have asked us for a feature that lets them know if floating window is currently in active browser tab or not.

- Added `PAGE_VISIBILITY_STATE` event that indicates whether browser's tab is visible or hidden. 