### PR TITLE
Add missing View and VisibilityEventInvoker for umd default export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Add missing View and VisibilityEventInvoker for umd default export
+
 ## [0.8.0] - 2023-05-04
 
 ### Added

--- a/src/umd.ts
+++ b/src/umd.ts
@@ -1,4 +1,14 @@
-import AppExtensionsSDK, { Command, Event, Modal, ModalStatus, Color, TrackingEvent, MessageType } from './index';
+import AppExtensionsSDK, {
+	Command,
+	Event,
+	Modal,
+	ModalStatus,
+	Color,
+	TrackingEvent,
+	MessageType,
+	View,
+	VisibilityEventInvoker,
+} from './index';
 
 export default Object.assign(AppExtensionsSDK, {
 	Command,
@@ -8,4 +18,6 @@ export default Object.assign(AppExtensionsSDK, {
 	Color,
 	TrackingEvent,
 	MessageType,
+	View,
+	VisibilityEventInvoker,
 });


### PR DESCRIPTION
## Problem

`AppExtensionsSDK.View` and `AppExtensionsSDK.VisibilityEventInvoker` is not available in UMD export

https://devcommunity.pipedrive.com/t/invalid-command-custom-floating-window/6917/3