### PR TITLE
GRAL-4106 User theme setting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,12 +25,12 @@ class AppExtensionsSDK {
 	public userSettings: UserSettings;
 
 	constructor(options: Options = {}) {
-		const { identifier, targetWindow, userSettings } = options;
+		const { identifier, targetWindow } = options;
 
 		this.initialized = false;
 		this.window = targetWindow ?? window.parent;
 		this.identifier = identifier ?? detectIdentifier();
-		this.userSettings = userSettings ?? detectUserSettings();
+		this.userSettings = detectUserSettings();
 
 		if (!this.identifier) {
 			throw new Error('Missing custom UI identifier');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { detectIdentifier, detectIframeFocus } from './utils';
+import { detectIdentifier, detectIframeFocus, detectUserSettings } from './utils';
 import {
 	Command,
 	CommandResponse,
@@ -12,6 +12,7 @@ import {
 	Payload,
 	TrackingEvent,
 	PageStateResponse,
+	UserSettings,
 } from './types';
 
 const commandKeys = Object.values(Command);
@@ -21,13 +22,15 @@ class AppExtensionsSDK {
 	private readonly identifier: string;
 	private initialized: boolean;
 	private window: Window;
+	public userSettings: UserSettings;
 
 	constructor(options: Options = {}) {
-		const { identifier, targetWindow } = options;
+		const { identifier, targetWindow, userSettings } = options;
 
 		this.initialized = false;
 		this.window = targetWindow ?? window.parent;
 		this.identifier = identifier ?? detectIdentifier();
+		this.userSettings = userSettings ?? detectUserSettings();
 
 		if (!this.identifier) {
 			throw new Error('Missing custom UI identifier');

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,9 +9,9 @@ import {
 	MessageChannelCommandResponse,
 	MessageType,
 	Options,
+	PageStateResponse,
 	Payload,
 	TrackingEvent,
-	PageStateResponse,
 	UserSettings,
 } from './types';
 
@@ -129,6 +129,10 @@ class AppExtensionsSDK {
 			}
 
 			onEventReceived(data);
+
+			if (event === Event.USER_SETTINGS_CHANGE && data) {
+				this.userSettings = data as UserSettings;
+			}
 		};
 
 		this.window.postMessage(message, '*', [channel.port2]);

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,7 @@ export enum Event {
 	VISIBILITY = 'visibility',
 	CLOSE_CUSTOM_MODAL = 'close_custom_modal',
 	PAGE_VISIBILITY_STATE = 'page_visibility_state',
+	USER_SETTINGS_CHANGE = 'user_settings_change',
 }
 
 export enum MessageType {
@@ -208,6 +209,9 @@ export type EventResponse<T extends Event> = {
 		[Event.CLOSE_CUSTOM_MODAL]: void;
 		[Event.PAGE_VISIBILITY_STATE]: {
 			state: 'visible' | 'hidden';
+		};
+		[Event.USER_SETTINGS_CHANGE]: {
+			theme: UserSettingsTheme;
 		};
 	}[T];
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,15 @@
+export enum UserSettingsTheme {
+	dark = 'dark',
+	light = 'light',
+}
+export type UserSettings = {
+	theme: UserSettingsTheme;
+};
+
 export type Options = {
 	identifier?: string;
 	targetWindow?: Window;
+	userSettings?: UserSettings;
 };
 
 export enum Command {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,15 +1,6 @@
-export enum UserSettingsTheme {
-	dark = 'dark',
-	light = 'light',
-}
-export type UserSettings = {
-	theme: UserSettingsTheme;
-};
-
 export type Options = {
 	identifier?: string;
 	targetWindow?: Window;
-	userSettings?: UserSettings;
 };
 
 export enum Command {
@@ -141,6 +132,15 @@ export enum VisibilityEventInvoker {
 	USER = 'user',
 	COMMAND = 'command',
 }
+
+export enum UserSettingsTheme {
+	DARK = 'dark',
+	LIGHT = 'light',
+}
+
+export type UserSettings = {
+	theme: UserSettingsTheme;
+};
 
 export type Args<T extends Command> = {
 	[Command.INITIALIZE]: InitializationOptions;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { UserSettings, UserSettingsTheme } from './types';
+
 type Callback = () => void;
 
 export function detectIframeFocus(cb: Callback) {
@@ -19,4 +21,12 @@ export function detectIdentifier() {
 	const params = new URLSearchParams(window.location.search);
 
 	return params.get('id');
+}
+
+export function detectUserSettings(): UserSettings {
+	const params = new URLSearchParams(window.location.search);
+
+	return {
+		theme: params.get('theme') === UserSettingsTheme.dark ? UserSettingsTheme.dark : UserSettingsTheme.light,
+	};
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,6 +27,6 @@ export function detectUserSettings(): UserSettings {
 	const params = new URLSearchParams(window.location.search);
 
 	return {
-		theme: params.get('theme') === UserSettingsTheme.dark ? UserSettingsTheme.dark : UserSettingsTheme.light,
+		theme: params.get('theme') === UserSettingsTheme.DARK ? UserSettingsTheme.DARK : UserSettingsTheme.LIGHT,
 	};
 }


### PR DESCRIPTION
## Problem

Pipedrive UI now supports 2 themes: dark and light. We need a way to provide this information to SDK, so Custom extension could apply styles based on user preferences.

## Changes

- detect userSettings from query param
- add new event `USER_SETTINGS_CHANGE` to apply the styles immediately on user preferences change
- provide access to `userSettings` property in SDK object

## Testing

Example of usage:
```
const sdk = new AppExtensionsSDK();

// add the attribute to HTML tag and apply specific CSS
document.documentElement.setAttribute('data-theme', sdk.userSettings.theme);

// listen to event when user changes the theme in Pipedrive UI
sdk.listen(Event.USER_SETTINGS_CHANGE, ({ error, data }) => {
	if (data) {
		document.documentElement.setAttribute('data-theme', data.theme);
	}
});

await sdk.initialize();
```