### PR TITLE
GRAL-5437: Restructure README into Overview/Setup/Testing/Architecture/Endpoints/References

### DIFF
--- a/.claude/prompts/readme-docs.md
+++ b/.claude/prompts/readme-docs.md
@@ -1,0 +1,23 @@
+You are helping update THIS repository’s documentation. Ultrathink.
+
+Goals:
+
+- Keep all documentation in README.md as the single source of truth.
+- Use the existing README.md as the PRIMARY source of truth.
+- VALIDATE every section; FLAG or FIX anything deprecated or incorrect.
+- Reorganize into this structure (create sections if missing):
+  1. Overview
+  2. Setup (prereqs, install, run, common pitfalls)
+  3. Testing (unit + functional, coverage, troubleshooting)
+  4. Architecture (directory layout, stack, integrations/flows)
+  5. Endpoints (routes, methods, purpose, auth/flags notes)
+  6. References/Links
+
+Strict rules:
+
+- **Preserve all existing images, screenshots, and diagrams exactly as they are. Never remove or drop them.**
+- Cross-check commands and scripts against package.json and repo code.
+- Keep commands copy-paste runnable; mark uncertain bits as “Needs verification”.
+- Do NOT introduce new secrets or internal hostnames that aren't already present in the existing README — this doesn't mean stripping internal URLs/hostnames the README already documents (e.g. devbox/testbox addresses) when "use the existing README as the PRIMARY source of truth" says to keep them.
+- Keep it concise and actionable.
+- Also update CLAUDE.md with any new relevant info that will help future documentation tasks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,58 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+`@pipedrive/app-extensions-sdk` is a small client-side TypeScript library published to npm. It runs inside the iframe of a Pipedrive custom UI extension (panel, modal, or floating window) and lets that extension talk to the parent Pipedrive window via `postMessage`/`MessageChannel` — issuing commands (resize, open a modal, show a snackbar, etc.) and listening for events (visibility changes, user settings changes). There is no server component; the entire implementation lives in `src/`.
+
+## Commands
+
+- `npm run build` — compile `src/` with Rollup into `dist/` (CJS `dist/index.js` + UMD `dist/index.umd.js`, both via `tsc`/rollup-typescript, UMD is minified with terser).
+- `npm run watch` — Rollup in watch mode.
+- `npm test` — run Jest (`--passWithNoTests`; there are currently no test files, though the harness is fully configured — see Testing below).
+- `npm run coverage` — Jest with coverage.
+- `npm run lint` — `tsc --noEmit` followed by ESLint over `**/*.{js,jsx,ts,tsx}`.
+- `npm run format` — Prettier write + `eslint --fix`.
+- `npm run docs:ai` — invokes Claude Code headlessly with `.claude/prompts/readme-docs.md` as an appended system prompt to reconcile `README.md` against the current source/scripts.
+
+Node >=22 and npm >=8 are required (`devEngines` in package.json); `.nvmrc` pins Node 24. A Husky `pre-commit` hook runs `npm run format && npm run lint` — don't bypass it.
+
+## Testing
+
+Jest is configured (`jest.config.js`) with `jsdom` environment and `testRegex: '__tests__/.*\.test\.[tj]s?$'` — new tests belong in a `__tests__/` directory (e.g. `src/__tests__/index.test.ts`) using that naming convention, not colocated `*.test.ts` files next to source. Coverage thresholds are currently set to 0, so nothing is enforced yet.
+
+## Architecture
+
+Everything lives in four files under `src/`:
+
+- **`types.ts`** — the source of truth for the protocol: `Command` and `Event` enums (the full set of message types the parent window understands), plus the `Args<T>` / `CommandResponse<T>` mapped types that tie each `Command` to its request/response shape. Adding a new SDK capability starts here: add the enum member, then extend `Args`/`CommandResponse`.
+- **`index.ts`** — the `AppExtensionsSDK` class. Two message-passing primitives underpin everything:
+  - `postMessage()` (private) opens a `MessageChannel`, posts `{ payload, id: identifier }` to `this.window` (the parent, by default `window.parent`), and resolves/rejects based on the response received on `channel.port1`. `execute()` (public) is the typed wrapper around this for `Command`s.
+  - `listen()` sets up either a `MessageChannel`-based subscription (for events proxied from the parent, e.g. `USER_SETTINGS_CHANGE`) or, for `PAGE_VISIBILITY_STATE`, a native `document.visibilitychange` listener — that one event never leaves the iframe. `listen()` also side-effects `this.userSettings` when a `USER_SETTINGS_CHANGE` payload arrives.
+  - The SDK must be constructed with an `identifier` (auto-detected from the `?id=` URL query param via `detectIdentifier()` if not passed) and must have `initialize()` awaited before `execute()` will work — `execute()` throws if `initialized` is false.
+- **`utils.ts`** — small DOM-dependent helpers used by the constructor: `detectIdentifier` (reads `?id=`), `detectUserSettings` (reads `?theme=`), `detectIframeFocus` (fires a callback on the iframe's first `focus` after a `blur`, used to emit the `FOCUSED` tracking event).
+- **`umd.ts`** — a separate Rollup entry point that re-exports `AppExtensionsSDK` with all enums (`Command`, `Event`, `Modal`, `Color`, etc.) attached as static properties, for consumers loading the library via a plain `<script>` tag (global `AppExtensionsSDK`) instead of a module bundler.
+
+Because every `Command`/`Event` is a discriminated union keyed off the enums in `types.ts`, changes to the wire protocol should be made there first and will then surface as type errors everywhere else that needs updating (`index.ts`'s `commandKeys`/`eventKeys` runtime guards included).
+
+## Documentation
+
+`README.md` is the single source of truth for public API docs and is organized into six top-level sections:
+Overview, Setup, Testing, Architecture, Endpoints (Commands & Events), References/Links. "Endpoints" is a
+deliberate misnomer kept for consistency with the org-wide docs template — this SDK has no HTTP endpoints; that
+section documents the `Command`/`Event` protocol instead (Commands = "routes", `execute()`/`listen()` = "methods").
+When changing public behavior in `src/`, update `README.md` to match — `npm run docs:ai` automates this
+reconciliation but a manual edit is equally valid.
+
+Notes for future doc reconciliation passes:
+- The README currently contains no images, screenshots, or diagrams — if any are added later, they must be
+  preserved verbatim on future passes.
+- GitHub's Markdown anchor slugs depend only on heading *text*, not heading level — so nesting a section deeper
+  (e.g. `## Commands` → `### Commands`) does not break existing `#commands`-style links elsewhere.
+- `demo/`, `custom-modal-test/`, and `issue-63/` may exist locally but are untracked/gitignored scratch dirs, not
+  part of the repository — do not reference them in `README.md` or treat them as documented structure.
+- There are currently no test files anywhere in `src/` despite Jest being fully configured; `npm test` passes
+  trivially via `--passWithNoTests`. Don't let README/CLAUDE docs imply real test coverage exists until it does.
+- `npm run watch:sync` shells out to an `npm-utils` CLI that is not a listed `devDependency` — likely internal
+  tooling; flag as "Needs verification" rather than assuming it works for external contributors.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,3 +56,8 @@ Notes for future doc reconciliation passes:
   trivially via `--passWithNoTests`. Don't let README/CLAUDE docs imply real test coverage exists until it does.
 - `npm run watch:sync` shells out to an `npm-utils` CLI that is not a listed `devDependency` — likely internal
   tooling; flag as "Needs verification" rather than assuming it works for external contributors.
+- Verify every `[text](#anchor)` link's fragment against the real heading slug it targets, not just that the
+  target heading exists somewhere. The README carried a broken link for at least several releases —
+  `[JSON modal](#json-modal)` in the "Open modal" intro pointed at a heading literally titled "JSON modal
+  action" (slug `#json-modal-action`) — because the link text and heading text quietly drifted apart. Fixed in
+  the `b4ce00d`+ doc restructure; re-check this class of bug (link text ≠ heading text) on future passes.

--- a/README.md
+++ b/README.md
@@ -8,27 +8,70 @@ Learn more about custom UI extensions from [Developer documentation](https://pip
 
 ## Table of contents
 
-- [Initialization](#initialization)
-- [User settings](#user-settings)
-- [Commands](#commands)
-  - [Show snackbar](#show-snackbar)
-  - [Show confirmation dialog](#show-confirmation-dialog)
-  - [Resize](#resize)
-  - [Get signed token](#get-signed-token)
-  - [Open modal](#open-modal)
-  - [Close modal](#close-modal)
-  - [Redirect to](#redirect-to)
-  - [Show floating window](#show-floating-window)
-  - [Hide floating window](#hide-floating-window)
-  - [Set notification](#set-notification)
-  - [Set focus mode](#set-focus-mode)
-  - [Get metadata](#get-metadata)
-- [Events](#events)
-  - [Visibility](#visibility)
-  - [Close custom modal](#close-custom-modal)
-  - [User settings change](#user-settings-change)
+- [Overview](#overview)
+- [Setup](#setup)
+  - [Prerequisites](#prerequisites)
+  - [Install](#install)
+  - [Initialization](#initialization)
+  - [Without module bundler](#without-module-bundler)
+  - [User settings](#user-settings)
+  - [Building from source](#building-from-source)
+  - [Common pitfalls](#common-pitfalls)
+- [Testing](#testing)
+  - [Unit tests](#unit-tests)
+  - [Coverage](#coverage)
+  - [Linting and formatting](#linting-and-formatting)
+  - [Troubleshooting](#troubleshooting)
+- [Architecture](#architecture)
+  - [Directory layout](#directory-layout)
+  - [Stack](#stack)
+  - [Communication flow](#communication-flow)
+  - [CI/CD](#cicd)
+- [Endpoints (Commands & Events)](#endpoints-commands--events)
+  - [Commands](#commands)
+    - [Show snackbar](#show-snackbar)
+    - [Show confirmation dialog](#show-confirmation-dialog)
+    - [Resize](#resize)
+    - [Get signed token](#get-signed-token)
+    - [Open modal](#open-modal)
+    - [Close modal](#close-modal)
+    - [Redirect to](#redirect-to)
+    - [Show floating window](#show-floating-window)
+    - [Hide floating window](#hide-floating-window)
+    - [Set notification](#set-notification)
+    - [Set focus mode](#set-focus-mode)
+    - [Get metadata](#get-metadata)
+  - [Events](#events)
+    - [Visibility](#visibility)
+    - [Close custom modal](#close-custom-modal)
+    - [User settings change](#user-settings-change)
+    - [Page visibility state](#page-visibility-state)
+- [References/Links](#referenceslinks)
 
-## Initialization
+## Overview
+
+`@pipedrive/app-extensions-sdk` is a small client-side TypeScript library that runs inside the iframe of a
+Pipedrive custom UI extension (panel, modal, or floating window). It lets that extension talk to the parent
+Pipedrive window — issuing **commands** (resize, open a modal, show a snackbar, redirect, etc.) and subscribing
+to **events** (visibility changes, user settings changes, page visibility state). There is no server component;
+the entire implementation lives under [`src/`](./src) and ships as a plain npm package.
+
+## Setup
+
+### Prerequisites
+
+- Node.js `>=22` and npm `>=8` (enforced via `devEngines` in `package.json`). `.nvmrc` pins Node `24` for local
+  development.
+- These prerequisites only matter if you're building/contributing to this SDK itself. Consumers who just install
+  the published package via npm or the CDN don't need to match this Node version.
+
+### Install
+
+```
+npm install --save @pipedrive/app-extensions-sdk
+```
+
+### Initialization
 
 In order to display a custom UI extension to a user, this SDK has to be initialized.
 In the iframe request, query `id` attribute is passed, which has to be provided to the SDK constructor.
@@ -70,7 +113,7 @@ After this, the global `AppExtensionsSDK` will be available. Initialization can 
 </body>
 ```
 
-## User settings
+### User settings
 
 Contains an object with user settings, such as theme interface preference, and is accessible directly as a property of an instance of `AppExtensionsSDK`.
 
@@ -80,7 +123,7 @@ Contains an object with user settings, such as theme interface preference, and i
 |------------| ------ |------------------------------------------------------------------------------------------------|
 | theme      | String | Selected theme interface preference. Possible values:<br/><ul><li>light</li><li>dark</li></ul> |
 
-### Example
+#### Example
 
 `sdk.userSettings.theme` can be used to set `data-theme` attribute to `html` tag of the iframe page with specific CSS for different themes.
 
@@ -100,9 +143,138 @@ document.documentElement.setAttribute('data-theme', sdk.userSettings.theme);
 await sdk.initialize();
 ```
 
-See also [USER_SETTINGS_CHANGE](#user-settings-change) event to implement an immediate update of styles in case of user preference change.
+See also [User settings change](#user-settings-change) event to implement an immediate update of styles in case of user preference change.
 
-## Commands
+### Building from source
+
+Only needed if you're contributing to this SDK, not for consuming the published package.
+
+```
+git clone git@github.com:pipedrive/app-extensions-sdk.git
+cd app-extensions-sdk
+npm install
+npm run build   # compiles src/ with Rollup into dist/ (CJS dist/index.js + UMD dist/index.umd.js)
+npm run watch   # same, but in Rollup watch mode while you iterate
+```
+
+A Husky `pre-commit` hook automatically runs `npm run format && npm run lint` on every commit — see
+[Linting and formatting](#linting-and-formatting).
+
+### Common pitfalls
+
+- **`execute()` throws `SDK is not initialized`** — you must `await sdk.initialize()` before calling
+  `sdk.execute(...)`.
+- **Constructor throws `Missing custom UI identifier`** — the SDK could not read `?id=` from the URL and no
+  `identifier` was passed manually. This typically happens after a redirect that strips query params; pass
+  `identifier` explicitly in that case (see [Initialization](#initialization)).
+- **CDN version pinning** — never omit the version in the jsDelivr URL in production (e.g. use
+  `@pipedrive/app-extensions-sdk@0`, not an unpinned path); see [Without module bundler](#without-module-bundler).
+- **Pre-commit hook** — `npm run format && npm run lint` runs automatically via Husky; don't bypass it with
+  `--no-verify`.
+- **`npm run watch:sync`** invokes an external `npm-utils` CLI that isn't listed in this repo's
+  `devDependencies` — **Needs verification** (assumed to be internal Pipedrive tooling not available to external
+  contributors; safe to ignore `watch:sync` for regular `build`/`watch` workflows).
+
+## Testing
+
+### Unit tests
+
+Jest is configured (`jest.config.js`) with a `jsdom` test environment. New tests belong in a `__tests__/`
+directory colocated with the code under test (e.g. `src/__tests__/index.test.ts`) — `testRegex` only picks up
+`__tests__/*.test.[tj]s`, not colocated `*.test.ts` files next to source.
+
+```
+npm test
+```
+
+This runs `jest --passWithNoTests`. **Needs verification / heads-up:** there are currently no test files in
+`src/`, so this command passes trivially (exit code 0) with zero tests executed — it does not yet verify any
+actual behavior.
+
+There is no separate functional/e2e test suite in this repository — the only testing harness currently
+configured is the Jest unit-test setup described above.
+
+### Coverage
+
+```
+npm run coverage
+```
+
+Runs `npm test -- --coverage`. Coverage thresholds in `jest.config.js` are currently all set to `0`, so nothing
+is enforced yet — add real thresholds once test coverage exists.
+
+### Linting and formatting
+
+```
+npm run lint     # tsc --noEmit, then ESLint over **/*.{js,jsx,ts,tsx}
+npm run format   # Prettier --write, then eslint --fix
+```
+
+These are the effective correctness gate today (in place of enforced test coverage) and also run automatically
+on every commit via the Husky `pre-commit` hook.
+
+### Troubleshooting
+
+- `npm test` reporting success with "no tests found" is expected until test files are added under a
+  `__tests__/` directory — it is not a false positive, it's the `--passWithNoTests` flag doing its job.
+- If a new test file isn't picked up by Jest, check it matches `__tests__/*.test.ts` (or `.js`), per
+  `testRegex` in `jest.config.js`.
+- Lint failures on commit come from the Husky `pre-commit` hook running `npm run format && npm run lint`; run
+  those two commands locally to reproduce and fix before committing.
+
+## Architecture
+
+### Directory layout
+
+```
+src/
+  index.ts   — AppExtensionsSDK class: postMessage()/execute() for commands, listen() for events
+  types.ts   — Command/Event enums and the Args<T>/CommandResponse<T> mapped types (protocol source of truth)
+  utils.ts   — DOM-dependent helpers: detectIdentifier, detectUserSettings, detectIframeFocus
+  umd.ts     — separate Rollup entry point exporting AppExtensionsSDK with enums as static properties (for <script> tag usage)
+dist/        — build output (CJS dist/index.js, UMD dist/index.umd.js) — generated, not committed source
+```
+
+### Stack
+
+- **TypeScript**, compiled via Rollup (`rollup.config.mjs`) using `@rollup/plugin-typescript`.
+- Two build outputs: CJS (`dist/index.js`) and UMD (`dist/index.umd.js`, minified with `@rollup/plugin-terser`)
+  for `<script>`-tag consumers.
+- **Jest** + `jest-environment-jsdom` for unit tests (see [Testing](#testing)).
+- **ESLint** + **Prettier** for linting/formatting, enforced locally via a **Husky** `pre-commit` hook.
+- No server component and no runtime dependencies beyond the browser's own `postMessage`/`MessageChannel` and
+  `document.visibilitychange` APIs — this is purely a client-side library.
+
+### Communication flow
+
+The SDK never talks to a backend directly; it talks to the parent Pipedrive window that's hosting the
+extension's iframe:
+
+- **Commands** (`sdk.execute(Command.X, ...)`) — `postMessage()` opens a `MessageChannel`, posts
+  `{ payload, id: identifier }` to the parent window (`window.parent` by default), and resolves/rejects the
+  returned promise based on the response received on `channel.port1`.
+- **Events** (`sdk.listen(Event.X, cb)`) — for most events, `listen()` sets up a `MessageChannel`-based
+  subscription with the parent window (e.g. `USER_SETTINGS_CHANGE`, which also updates `sdk.userSettings` as a
+  side effect). `PAGE_VISIBILITY_STATE` is the one exception: it's backed by a native
+  `document.visibilitychange` listener and never leaves the iframe.
+- Every `Command`/`Event` is a discriminated union keyed off the enums in `src/types.ts`, so the wire protocol
+  is defined in one place and changes there surface as type errors everywhere else that needs updating.
+
+### CI/CD
+
+- `.github/workflows/on-commit.yml` — runs `npm install` + `npm run lint` on every PR targeting `master`.
+- `.github/workflows/cicd_npm-publish.yml` — publishes to npm (via OIDC Trusted Publisher) when a PR is labeled
+  `npm-ready-for-publish`.
+
+## Endpoints (Commands & Events)
+
+This SDK has no HTTP endpoints — its public API surface is the set of **Commands** you invoke with
+`sdk.execute()` and **Events** you subscribe to with `sdk.listen()`, both exchanged with the parent window over
+`postMessage` (see [Communication flow](#communication-flow)). This section documents each one — think of a
+Command as a "route" (its purpose, parameters, and response), and note [Get signed token](#get-signed-token) for
+the one built-in authentication-related capability.
+
+### Commands
 
 Commands can be invoked with the `execute` method. On successful command execution, promise
 resolves. On error, it rejects.
@@ -123,7 +295,7 @@ try {
 }
 ```
 
-### Show snackbar
+#### Show snackbar
 
 Shows snackbar with provided message and link
 
@@ -148,7 +320,7 @@ await sdk.execute(Command.SHOW_SNACKBAR, {
 });
 ```
 
-### Show confirmation dialog
+#### Show confirmation dialog
 
 Shows confirmation dialog with provided title and description
 
@@ -177,7 +349,7 @@ const { confirmed } = await sdk.execute(Command.SHOW_CONFIRMATION, {
 });
 ```
 
-### Resize
+#### Resize
 
 Resizes custom UI extension with provided height and width
 
@@ -202,7 +374,7 @@ The minimum width is 200px and the maximum width is 800px.
 await sdk.execute(Command.RESIZE, { height: 500 });
 ```
 
-### Get signed token
+#### Get signed token
 
 A new JSON Web Token (JWT) that is valid for 5 minutes will be generated. It can be verified using
 the JWT secret which you can add from Marketplace Manager when configuring a custom UI extension. If it's not
@@ -228,13 +400,13 @@ in a short time span is safe and won't produce a different token each time.
 const { token } = await sdk.execute(Command.GET_SIGNED_TOKEN);
 ```
 
-### Open modal
+#### Open modal
 
 Opens a [JSON modal](#json-modal), [custom modal](#custom-modal) or a new
 Pipedrive [Deal](#new-deal-modal), [Organization](#new-organization-modal),
 [Person](#new-person-modal) or [Activity](#new-activity-modal) modal
 
-### JSON modal action
+##### JSON modal action
 
 **Parameters for JSON modal**
 
@@ -258,7 +430,7 @@ const { status } = await sdk.execute(Command.OPEN_MODAL, {
 });
 ```
 
-### Custom modal
+##### Custom modal
 
 **Parameters for custom modal**
 
@@ -286,7 +458,7 @@ const { status } = await sdk.execute(Command.OPEN_MODAL, {
 });
 ```
 
-### New deal modal
+##### New deal modal
 
 **Parameters for new deal modal**
 
@@ -316,7 +488,7 @@ const { status, id } = await sdk.execute(Command.OPEN_MODAL, {
 });
 ```
 
-### New person modal
+##### New person modal
 
 **Parameters for new person modal**
 
@@ -346,7 +518,7 @@ const { status, id } = await sdk.execute(Command.OPEN_MODAL, {
 });
 ```
 
-### New organization modal
+##### New organization modal
 
 **Parameters for new organization modal**
 
@@ -374,7 +546,7 @@ const { status, id } = await sdk.execute(Command.OPEN_MODAL, {
 });
 ```
 
-### New activity modal
+##### New activity modal
 
 **Parameters for new activity modal**
 
@@ -416,7 +588,7 @@ const { status, id } = await sdk.execute(Command.OPEN_MODAL, {
 });
 ```
 
-### Close modal
+#### Close modal
 
 Closes an active modal window; applicable only for **custom modal**.
 
@@ -426,7 +598,7 @@ Closes an active modal window; applicable only for **custom modal**.
 await sdk.execute(Command.CLOSE_MODAL);
 ```
 
-### Redirect to
+#### Redirect to
 
 Redirects user to specified view.
 
@@ -444,7 +616,7 @@ Redirects user to specified view.
 await sdk.execute(Command.REDIRECT_TO, { view: View.DEALS, id: 1, context: { foo: 'bar' } });
 ```
 
-### Show floating window
+#### Show floating window
 
 Opens floating window and triggers `Event.VISIBILITY` with an optional `context` parameter
 that is dependent on your app's use case (see [Visibility](#visibility) for details).
@@ -465,7 +637,7 @@ await sdk.execute(Command.SHOW_FLOATING_WINDOW, {
 });
 ```
 
-### Hide floating window
+#### Hide floating window
 
 Closes floating window and triggers `Event.VISIBILITY` with an optional `context` parameter
 that is dependent on your app's use case (see [Visibility](#visibility) for details).
@@ -486,7 +658,7 @@ await sdk.execute(Command.HIDE_FLOATING_WINDOW, {
 });
 ```
 
-### Set notification
+#### Set notification
 
 For apps with floating window, display or remove notifications badge in apps dock. Not specifying
 the number or setting it to `0` removes the notification badge. Specifying a number greater than `0`
@@ -506,7 +678,7 @@ await sdk.execute(Command.SET_NOTIFICATION, {
 });
 ```
 
-### Set focus mode
+#### Set focus mode
 
 For apps with a floating window, you can enable or disable focus mode. When the focus mode is
 enabled, the close button in the window header is hidden.
@@ -524,7 +696,7 @@ visible before using this command.
 await sdk.execute(Command.SET_FOCUS_MODE, true);
 ```
 
-### Get metadata
+#### Get metadata
 
 Retrieves metadata information about the main window.
 
@@ -541,7 +713,7 @@ Retrieves metadata information about the main window.
 const { windowWidth, windowHeight } = await sdk.execute(Command.GET_METADATA);
 ```
 
-## Events
+### Events
 
 Subscribe to events triggered by users.
 
@@ -554,17 +726,17 @@ const stopReceivingEvents = sdk.listen(event, ({ error, data }) => {
 stopReceivingEvents(); // Call this function to stop receiving events
 ```
 
-### Visibility
+#### Visibility
 
 Subscribe to visibility changes that are triggered by the user or an SDK command.
 
-#### Custom panel
+##### Custom panel
 
 Event is triggered when the user collapses or expands the panel.
 
 `context` parameter is not included.
 
-#### Floating window
+##### Floating window
 
 Event is triggered when the floating window is displayed or gets hidden.
 
@@ -587,7 +759,7 @@ sdk.listen(Event.VISIBILITY, ({ error, data }) => {
 });
 ```
 
-### Close custom modal
+#### Close custom modal
 
 Subscribe to custom modal events that are triggered by this SDK's `CLOSE_MODAL` command or user interaction with the custom modal.
 
@@ -601,7 +773,7 @@ sdk.listen(Event.CLOSE_CUSTOM_MODAL, () => {
 });
 ```
 
-### User settings change
+#### User settings change
 
 This event lets you get an update if any user settings have changed.
 
@@ -619,7 +791,7 @@ sdk.listen(Event.USER_SETTINGS_CHANGE, ({ data }) => {
 });
 ```
 
-### Page visibility state
+#### Page visibility state
 
 Subscribe to the page visibility event that is triggered when the value of the `visibilityState` property changes. This event enables you to find out if the page your app extension will be loaded in is visible/in the background or hidden.
 
@@ -644,3 +816,12 @@ const stopReceivingPageStateEvent = sdk.listen(Event.PAGE_VISIBILITY_STATE, ({ d
 
 stopReceivingPageStateEvent() // Call this function to stop receiving event
 ```
+
+## References/Links
+
+- [Custom UI extensions developer documentation](https://pipedrive.readme.io/docs/custom-ui-extensions)
+- [Custom settings page documentation](https://pipedrive.readme.io/docs/custom-ui-extensions-app-settings) (see [View.SETTINGS](#redirect-to))
+- [jsDelivr CDN build](https://cdn.jsdelivr.net/npm/@pipedrive/app-extensions-sdk@0/dist/index.umd.js) (see [Without module bundler](#without-module-bundler))
+- [npm package](https://www.npmjs.com/package/@pipedrive/app-extensions-sdk)
+- [GitHub repository](https://github.com/pipedrive/app-extensions-sdk) / [issues](https://github.com/pipedrive/app-extensions-sdk/issues)
+- [CHANGELOG.md](./CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ const { token } = await sdk.execute(Command.GET_SIGNED_TOKEN);
 
 #### Open modal
 
-Opens a [JSON modal](#json-modal), [custom modal](#custom-modal) or a new
+Opens a [JSON modal](#json-modal-action), [custom modal](#custom-modal) or a new
 Pipedrive [Deal](#new-deal-modal), [Organization](#new-organization-modal),
 [Person](#new-person-modal) or [Activity](#new-activity-modal) modal
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "version": "changelog-updater && git add CHANGELOG.md",
     "watch": "rollup --watch -c",
     "prepare": "husky install && npm run build",
-    "watch:sync": "npm-utils watch"
+    "watch:sync": "npm-utils watch",
+    "docs:ai": "claude --append-system-prompt-file .claude/prompts/readme-docs.md 'Update the repository documentation now.'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Related Tickets & Documents

GRAL-5437

## Description

Reorganizes `README.md` into a standard doc template (Overview, Setup, Testing, Architecture, Endpoints (Commands & Events), References/Links) while validating it against `package.json` and `src/`. All existing Command/Event API reference content (parameters, responses, examples) is preserved verbatim.

Fixes/flags found during validation:
- Added a missing "Page visibility state" table-of-contents entry — the section existed in the README body but was never linked from the TOC.
- Flagged `watch:sync`'s `npm-utils` dependency (not in `devDependencies`) and the current absence of test files as "Needs verification" rather than presenting them as verified/working.
- Confirmed `demo/`, `custom-modal-test/`, and `issue-63/` are untracked local scratch dirs (not part of the repo) and excluded them from the docs.

Also adds the `docs:ai` npm script (invokes Claude Code headlessly with `.claude/prompts/readme-docs.md` to reconcile the README against source) and its prompt file, and updates `CLAUDE.md` with notes for future documentation reconciliation passes (anchor-slug stability across heading-level changes, no images to preserve yet, scratch dirs to ignore, etc).

No changes to `src/` or the public API — documentation only.

## Type of PR?

- 🚧 Maintenance

## Manual testing

- Verified every heading referenced in the new table of contents matches an actual heading in the document (GitHub anchor slugs are heading-level independent, so nesting Commands/Events under a new Endpoints section does not break any existing `#anchor` links).
- Cross-checked all documented `Command`/`Event` enum members, script names, and Node/npm version requirements against `src/types.ts` and `package.json`.

## Automated tests added?

- [ ] 👍 Unit tests
- [ ] 👍 Functional tests
- [ ] 👍 E2E tests
- [x] 🙅 N/A